### PR TITLE
TXNCXX-11 API Implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,33 @@
 cmake_minimum_required(VERSION 3.11)
-project(transactions_cxx)
 
+# ============= BEGIN GTEST ============================================
+
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in ${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt)
+execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download"
+)
+execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download"
+)
+
+set (CMAKE_CXX_STANDARD 11)
+
+# Prevent GoogleTest from overriding our compiler/linker options
+# when building with Visual Studio
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This adds the following targets:
+# gtest, gtest_main, gmock and gmock_main
+add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+                 "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+)
+# ============= END GTEST ============================================
+# ============= BEGIN DEPS ==========================================
+project(transactions_cxx)
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
 
 option(BUILD_DOC "Build documentation" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
@@ -28,7 +53,8 @@ message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 
 find_package(spdlog REQUIRED)
-
+#============ END DEPS =======================================================
+#============ BEGIN CLIENT ===================================================
 include_directories(include ${PROJECT_SOURCE_DIR}/deps/libcouchbase/include ${PROJECT_BINARY_DIR}/deps/libcouchbase/generated)
 
 file(GLOB_RECURSE client_include_FILES ${PROJECT_SOURCE_DIR}/include/couchbase/client/*.hxx)
@@ -40,7 +66,8 @@ target_link_libraries(client_cxx
                       spdlog::spdlog
                       ${Boost_LIBRARIES}
                       couchbase)
-
+#============ END CLIENT ====================================================================
+# =========== BEGIN TRANSACTIONS ============================================================
 file(GLOB_RECURSE transactions_include_FILES ${PROJECT_SOURCE_DIR}/include/couchbase/transactions/*.hxx)
 file(GLOB_RECURSE transactions_src_FILES ${PROJECT_SOURCE_DIR}/src/transactions/*.cxx)
 add_library(transactions_cxx SHARED ${transactions_include_FILES} ${transactions_src_FILES})
@@ -50,7 +77,8 @@ target_link_libraries(transactions_cxx
                       spdlog::spdlog
                       ${Boost_LIBRARIES}
                       client_cxx)
-
+# =========== END TRANSACTIONS ================================================================
+# =========== BEGIN DOCS ======================================================================
 if(BUILD_DOC)
     find_package(Doxygen)
     if(DOXYGEN_FOUND)
@@ -66,7 +94,15 @@ if(BUILD_DOC)
         message(WARNING "Doxygen need to be installed to generate the doxygen documentation")
     endif()
 endif()
-
+#=========== END DOCS ============================================================================
+#=========== BEGIN EXAMPLES ======================================================================
 if(BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
+#========== END EXAMPLES =========================================================================
+#========== BEGIN TESTS ==========================================================================
+file(GLOB CLIENT_TEST_SOURCES "${PROJECT_SOURCE_DIR}/tests/client/*_t.cpp")
+include_directories(${GTEST_INCLUDE_DIRS})
+add_executable(client_tests ${CLIENT_TEST_SOURCES})
+target_link_libraries(client_tests client_cxx gtest gmock)
+

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.2)
+project(googletest-download)
+
+include(externalproject)
+externalproject_add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           release-1.8.1
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/tests/client/client_env.h
+++ b/tests/client/client_env.h
@@ -1,0 +1,48 @@
+#include <fstream>
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
+#include "couchbase/client/cluster.hxx"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+// hack, until I get gtest working a bit better and can execute
+// tests through make with proper working directory.
+#define CONFIG_FILE_NAME "../tests/config.json"
+
+class ClientTestEnvironment : public ::testing::Environment {
+  public:
+    void SetUp() override {
+        get_cluster();
+    }
+
+    static const nlohmann::json& get_conf() {
+        // read config.json
+        static nlohmann::json conf;
+        if (conf.empty()) {
+            spdlog::info("reading config file {}", CONFIG_FILE_NAME);
+            std::ifstream in(CONFIG_FILE_NAME, std::ifstream::in);
+            conf = nlohmann::json::parse(in);
+        }
+        return conf;
+
+    }
+
+    static std::shared_ptr<couchbase::cluster> get_cluster() {
+        auto conf = get_conf();
+        static auto cluster = std::make_shared<couchbase::cluster>(conf["connection_string"], conf["username"], conf["password"]);
+        return cluster;
+    }
+
+    static std::string get_uuid() {
+        static auto generator = boost::uuids::random_generator();
+        return boost::uuids::to_string(generator());
+    }
+
+    static std::shared_ptr<couchbase::collection> get_default_collection(const std::string& bucket_name) {
+        auto c = get_cluster();
+        auto b = c->bucket(bucket_name);
+        return b->default_collection();
+    }
+};

--- a/tests/client/simple_t.cpp
+++ b/tests/client/simple_t.cpp
@@ -1,0 +1,189 @@
+#include <memory>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "couchbase/client/cluster.hxx"
+#include "couchbase/client/collection.hxx"
+#include "client_env.h"
+
+using namespace couchbase;
+using ::testing::Mock;
+
+static std::string bucket_name = std::string("default");
+static nlohmann::json content = nlohmann::json::parse("{\"some\":\"thing\"}");
+
+static void upsert_random_doc(std::shared_ptr<couchbase::collection>& coll, std::string& id) {
+    id = ClientTestEnvironment::get_uuid();
+    if (!coll) {
+        auto c = ClientTestEnvironment::get_cluster();
+        auto b = c->bucket(bucket_name);
+        coll = b->default_collection();
+    }
+    auto result = coll->upsert(id, content);
+    ASSERT_TRUE(result.is_success());
+    ASSERT_EQ(result.rc, 0);
+    ASSERT_FALSE(result.is_not_found());
+    ASSERT_FALSE(result.is_value_too_large());
+    EXPECT_THAT(result.strerror(), testing::HasSubstr("LCB_SUCCESS"));
+    ASSERT_EQ(result.key, id);
+    ASSERT_FALSE(result.value.has_value());
+}
+
+TEST(SimpleClientClusterTests, ClusterConnect) {
+    // Really, since we get the cluster in the environment in SetUp, this
+    // isn't really necessary.  That would raise an exception at startup if
+    // it didn't connect, since we really want to cache the connection.
+    // Just here for completness, and if things change.
+    auto c = ClientTestEnvironment::get_cluster();
+    ASSERT_TRUE(c.get() != nullptr);
+}
+
+TEST(SimpleClientClusterTests, CanGetBucket) {
+    auto c = ClientTestEnvironment::get_cluster();
+    auto b = c->bucket("default");
+    ASSERT_TRUE(b.get() != nullptr);
+}
+
+TEST(SimpleClientClusterTests, CanGetBucket_NoBucket) {
+    auto c = ClientTestEnvironment::get_cluster();
+    auto random_bucket = ClientTestEnvironment::get_uuid();
+    ASSERT_THROW(c->bucket(random_bucket), std::runtime_error);
+}
+
+TEST(SimpleClientClusterTests, CanListBucketNames) {
+    auto c = ClientTestEnvironment::get_cluster();
+    auto buckets = c->buckets();
+    ASSERT_TRUE(std::find(buckets.begin(), buckets.end(), std::string("default")) != buckets.end());
+}
+
+TEST(SimpleClientBucketTests, CanGetDefaultCollection) {
+    auto c = ClientTestEnvironment::get_cluster();
+    auto b = c->bucket("default");
+    auto coll = b->default_collection();
+    ASSERT_TRUE(coll.get() != nullptr);
+}
+
+TEST(SimpleClientCollectionTests, CanInsert) {
+    auto id = ClientTestEnvironment::get_uuid();
+    auto content = nlohmann::json::parse("{\"some\":\"thing\"}");
+    auto c = ClientTestEnvironment::get_cluster();
+    auto b = c->bucket("default");
+    auto coll = b->default_collection();
+    auto result = coll->insert(id, content);
+    ASSERT_TRUE(result.is_success());
+    ASSERT_EQ(result.rc, 0);
+    ASSERT_FALSE(result.is_not_found());
+    ASSERT_FALSE(result.is_value_too_large());
+    EXPECT_THAT(result.strerror(), testing::HasSubstr("LCB_SUCCESS"));
+    ASSERT_EQ(result.key, id);
+    ASSERT_FALSE(result.value.has_value());
+}
+
+TEST(SimpleClientCollectionTests, CanUpsert) {
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+}
+
+TEST(SimpleClientCollectionTests, CanGet) {
+    // Of course, this depends on being able to upsert as well
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+    auto get_res = coll->get(id);
+    ASSERT_TRUE(get_res.is_success());
+    ASSERT_FALSE(get_res.is_not_found());
+    ASSERT_FALSE(get_res.is_value_too_large());
+    EXPECT_THAT(get_res.strerror(), testing::HasSubstr("LCB_SUCCESS"));
+    ASSERT_NE(get_res.cas, 0);
+    ASSERT_EQ(get_res.key, id);
+    ASSERT_EQ(get_res.rc, 0);
+    ASSERT_TRUE(get_res.value.has_value());
+    ASSERT_EQ(get_res.value.get(), content);
+}
+
+TEST(SimpleClientCollectionTests, CanGetDocNotFound) {
+    auto id = ClientTestEnvironment::get_uuid();
+    auto c = ClientTestEnvironment::get_cluster();
+    auto b = c->bucket("default");
+    auto coll = b->default_collection();
+    auto res = coll->get(id);
+    ASSERT_FALSE(res.is_success());
+    ASSERT_TRUE(res.is_not_found());
+    ASSERT_FALSE(res.is_value_too_large());
+    EXPECT_THAT(res.strerror(), testing::HasSubstr("DOCUMENT_NOT_FOUND"));
+    ASSERT_TRUE(res.key.empty());
+    ASSERT_EQ(res.rc, 301);
+}
+
+TEST(SimpleClientCollectionTests, CanRemove) {
+    // Of course, this depends on being able to upsert as well
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+    auto res = coll->remove(id);
+    ASSERT_TRUE(res.is_success());
+    res = coll->get(id);
+    ASSERT_FALSE(res.is_success());
+    ASSERT_TRUE(res.is_not_found());
+    ASSERT_FALSE(res.is_value_too_large());
+    ASSERT_TRUE(res.key.empty());
+    ASSERT_EQ(res.rc, 301);
+}
+
+TEST(SimpleClientCollectionTests, CanReplace) {
+    // Of course, this depends on being able to upsert and get.
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+    auto cas = coll->get(id).cas;
+    auto new_content = nlohmann::json::parse("{\"some\":\"thing else\"}");
+    auto res = coll->replace(id, new_content, cas);
+    ASSERT_TRUE(res.is_success());
+    res = coll->get(id);
+    ASSERT_TRUE(res.is_success());
+    ASSERT_NE(res.cas, cas);
+    ASSERT_EQ(res.value->get<nlohmann::json>(), new_content);
+}
+
+TEST(SimpleClientCollectionTests, CanLookupIn) {
+    // also depends on upsert
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+    auto res = coll->lookup_in(id, {couchbase::lookup_in_spec::get("some"), lookup_in_spec::fulldoc_get()});
+    ASSERT_TRUE(res.is_success());
+    ASSERT_FALSE(res.is_not_found());
+    ASSERT_FALSE(res.is_value_too_large());
+    ASSERT_EQ(res.key, id);
+    ASSERT_FALSE(res.value.has_value());
+    ASSERT_FALSE(res.values.empty());
+    ASSERT_EQ(res.values[0]->get<std::string>(), std::string("thing"));
+    ASSERT_EQ(res.values[1]->get<nlohmann::json>(), ::content);
+}
+
+TEST(SimpleClientCollectionTests, CanMutateIn) {
+    // also depends on upsert and get.
+    std::string id;
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    upsert_random_doc(coll, id);
+    auto res = coll->mutate_in(id, {couchbase::mutate_in_spec::upsert(std::string("some"), std::string("other thing")),
+                                    couchbase::mutate_in_spec::insert(std::string("another"), std::string("field"))});
+    ASSERT_TRUE(res.is_success());
+    res = coll->get(id);
+    ASSERT_TRUE(res.is_success());
+    ASSERT_TRUE(res.value.has_value());
+    ASSERT_EQ(res.value->get<nlohmann::json>(), nlohmann::json::parse("{\"some\":\"other thing\", \"another\":\"field\"}"));
+}
+
+TEST(SimpleClientCollectionTests, CanGetBucketNameEtc) {
+    auto coll = ClientTestEnvironment::get_default_collection(::bucket_name);
+    ASSERT_EQ(coll->bucket_name(), ::bucket_name);
+    ASSERT_TRUE(coll->name().empty());
+    ASSERT_TRUE(coll->scope().empty());
+}
+
+int main(int argc, char* argv[]) {
+    testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment(new ClientTestEnvironment());
+    return RUN_ALL_TESTS();
+}

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,6 @@
+{
+    "connection_string": "couchbase://10.143.202.101",
+    "username": "Administrator",
+    "password": "password"
+}
+

--- a/tests/include/environment.h
+++ b/tests/include/environment.h
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+#include "couchbase/client/
+#define CONFIG_FILE_NAME "config.json"
+class TestEnvironment : public ::testing::Environment {
+  public:
+    void SetUp() override {
+        // read config.json
+
+    }
+  private:
+


### PR DESCRIPTION
Motivation
==========
Needed some tests - at least for the client code, before considering
this issue closed.

Modification
============
A set of _simple_ client tests were added, using gtest.  So - some
CMake magic plus some simple gtests.  Later we can write more thorough
test suites, but this is enough to be able to develop further.

Result
======
Some passing tests.